### PR TITLE
add "weights" argument to odseq and odseq_unaligned

### DIFF
--- a/examples/weighting_examples.R
+++ b/examples/weighting_examples.R
@@ -1,0 +1,27 @@
+# Weighted odseq
+
+data(seqs)
+seqs <- sort(seqs)
+al1 <- msa(seqs, order = "input")
+
+# get only the unique sequences
+uniq_seqs <- unique(seqs)
+counts <- table(seqs)
+
+#get lines from the alignment corresponding to the first instance of each sequence
+al2 <- Biostrings::AAMultipleAlignment(al1@unmasked[!duplicated(seqs)])
+
+# verify that we can reproduce the sequences and alignments in the correct order
+stopifnot(names(counts) == uniq_seqs)
+stopifnot(rep(uniq_seqs, counts) == seqs)
+stopifnot(as.character(al1@unmasked) == rep(as.character(al2@unmasked), counts))
+
+# check timing
+# dereplicated + weights is faster
+# for this dataset both are fast, but for bigger datasets this can matter!
+# (dereplicating before alignment can also be a big speedup)
+system.time(od1 <- odseq(al1, B = 10000))
+system.time(od2 <- odseq(al2, B = 10000, weights = counts))
+
+# results are the same.
+stopifnot(od1 == rep(od2, counts))

--- a/odseq/R/odseq.R
+++ b/odseq/R/odseq.R
@@ -1,9 +1,9 @@
 odseq <-
 function(msa_object, distance_metric = "linear", B = 100,
-                  threshold = 0.025){
-  
+                  threshold = 0.025, weights = NULL){
+
   # Define gap and score functions, using vectorization
-  
+
   is.gap <- function(char){
     if(char == "-"){
       return(1)
@@ -12,36 +12,44 @@ function(msa_object, distance_metric = "linear", B = 100,
       return(0)
     }
   }
-  
+
   vector.gap <- function(seq){
     return(as.numeric(sapply(seq, is.gap)))
   }
-  
+
   linear_score <- function(seq1, seq2){
     sum(seq1 != seq2)
   }
-  
+
   linear_score_vec <- function(seq1, rest_sequences){
     sapply(rest_sequences, function(x){linear_score(seq1, x)})
   }
-  
+
   affine_score <- function(seq1, seq2){
     l <- length(seq1)
     seq1_left <- seq1[-1]
     seq2_left <- seq2[-1]
     seq1_right <- seq1[-l]
     seq2_right <- seq2[-l]
-    
+
     case1 = (seq1_left != seq2_left) & (seq1_right == seq2_right)
     case2 = (seq1_left != seq2_left) & (seq1_right != seq2_right)
-    
+
     sum(3*case1 + case2)
   }
-  
+
   affine_score_vec <- function(seq1, rest_sequences){
     sapply(rest_sequences, function(x){affine_score(seq1, x)})
   }
-  
+
+  weighted_sum <- if (is.null(weights)) {
+     sum
+  } else {
+     function(x) {
+        sum(x*weights)
+     }
+  }
+
   # Load msa object, and coerce it to list
   sequences <- msa_object@unmasked
   n <- length(sequences)
@@ -50,7 +58,7 @@ function(msa_object, distance_metric = "linear", B = 100,
   gap_sequences <- as.list(data.frame(t(gap_sequences)))
 
   # Compute distance matrix efficiently
-  
+
   if(distance_metric == "linear"){
     distance_matrix <- sapply(gap_sequences, function(x){linear_score_vec(x, gap_sequences)})
   } else if(distance_metric == "affine"){
@@ -59,21 +67,21 @@ function(msa_object, distance_metric = "linear", B = 100,
   else{
     stop("Distance metric not supported. Use linear or affine.")
   }
-  
+
   # Compute score for each sequence
-  
-  distance_scores <- apply(distance_matrix, 1, sum)
-  
+
+  distance_scores <- apply(distance_matrix, 1, weighted_sum)
+
   # Perform bootstrapping of distance scores
-  
-  distribution_scores <- replicate(B, {boot <- sample(distance_scores, n, replace = TRUE);
+
+  distribution_scores <- replicate(B, {boot <- sample(distance_scores, n, replace = TRUE, prob = weights);
                                       mean(boot)})
-  
+
   # Return logical vector of outliers, using threshold
-  
+
   confidence_interval <- quantile(distribution_scores, probs = c(threshold, 1 - threshold))
   outliers <- (distance_scores > confidence_interval[2])
-  
+
   return(outliers)
-  
+
 }

--- a/odseq/R/odseq_unaligned.R
+++ b/odseq/R/odseq_unaligned.R
@@ -1,21 +1,29 @@
-odseq_unaligned <- function(distance_matrix, B = 100, threshold = 0.025, type = "similarity"){
-  
-  n <- nrow(distance_matrix)
-  
-  # Compute score for each sequence
-  distance_scores <- apply(distance_matrix, 1, sum)
+odseq_unaligned <- function(distance_matrix, B = 100, threshold = 0.025, type = "similarity", weights = NULL){
 
-  # Perform bootstrap of distance scores  
-  
-  distribution_scores <- replicate(B, {boot <- sample(distance_scores, n, replace = TRUE);
+   weighted_sum <- if (is.null(weights)) {
+      sum
+   } else {
+      function(x) {
+         sum(x*weights)
+      }
+   }
+
+  n <- nrow(distance_matrix)
+
+  # Compute score for each sequence
+  distance_scores <- apply(distance_matrix, 1, weighted_sum)
+
+  # Perform bootstrap of distance scores
+
+  distribution_scores <- replicate(B, {boot <- sample(distance_scores, n, replace = TRUE, prob = weights);
                             mean(boot)})
-  
+
   # Return logical vector of outliers, using threshold
-  
+
   confidence_interval <- quantile(distribution_scores, probs = c(threshold, 1 - threshold))
-  
+
   if(type == "similarity"){
-    outliers <- distance_scores < confidence_interval[1]  
+    outliers <- distance_scores < confidence_interval[1]
   }
   else if(type == "distance"){
     outliers <- distance_scores > confidence_interval[2]
@@ -23,7 +31,7 @@ odseq_unaligned <- function(distance_matrix, B = 100, threshold = 0.025, type = 
   else{
     stop("Matrix type not supported. Choose similarity or distance.")
   }
-  
+
   return(outliers)
-  
+
 }

--- a/odseq/man/odseq.Rd
+++ b/odseq/man/odseq.Rd
@@ -7,7 +7,7 @@ Outlier detection in a multiple sequence alignment
 This function will first compute a distance metric among every sequence in the multiple alignment. Then it will bootstrap an average score of these distance to provide information on the distribution of scores, which is used to distinguish outlier sequences with a certain threshold
 }
 \usage{
-odseq(msa_object, distance_metric = "linear", B = 100, threshold = 0.025)
+odseq(msa_object, distance_metric = "linear", B = 100, threshold = 0.025, weights = NULL)
 }
 \arguments{
   \item{msa_object}{
@@ -21,6 +21,9 @@ Integer indicating the number of bootstrap replicates to be run. The higher the 
 }
   \item{threshold}{
 Float indicating the probability to be left at the right of the bootstrap scores distribution when computing outliers. This parameter may need some tuning depending on each specific problem
+}
+  \item{weights}{
+Numeric vector with the same length as the \code{msa_object}, giving weights for each sequence.  In particular, if these are integer values, then the result will be the same as if each sequence was repeated in the alignment a number of times equal to its weight, but will be calculated much more quickly.
 }
 }
 

--- a/odseq/man/odseq_unaligned.Rd
+++ b/odseq/man/odseq_unaligned.Rd
@@ -27,7 +27,7 @@ A string indicating the type of distance metric used. Either \code{'similarity'}
 }
 
   \item{weights}{
-Numeric vector with the same length as the \code{msa_object}, giving weights for each sequence.  In particular, if these are integer values, then the result will be the same as if each sequence was repeated in the alignment a number of times equal to its weight, but will be calculated much more quickly.
+Numeric vector with the same length as the \code{msa_object}, giving weights for each sequence.  In particular, if these are integer values, then the result will be the same as if each row and column in the distance matrix was repeated a number of times equal to its weight, but will be calculated much more quickly.
 }
 
 

--- a/odseq/man/odseq_unaligned.Rd
+++ b/odseq/man/odseq_unaligned.Rd
@@ -26,6 +26,10 @@ Float indicating the probability to be left at the right of the bootstrap scores
 A string indicating the type of distance metric used. Either \code{'similarity'} or \code{'distance'}.
 }
 
+  \item{weights}{
+Numeric vector with the same length as the \code{msa_object}, giving weights for each sequence.  In particular, if these are integer values, then the result will be the same as if each sequence was repeated in the alignment a number of times equal to its weight, but will be calculated much more quickly.
+}
+
 
 }
 


### PR DESCRIPTION
Weights are used when summing the distance matrix to generate a score for each sequence, and again when sampling for bootstrapping.  For integer weights, the result is the same as duplicating sequences, but calculation of the distance matrix is faster.  The new example file also demonstrates that the results for the example data are identical when duplicate sequences are removed and weights are used.